### PR TITLE
Fix window resize crash

### DIFF
--- a/src/SwapChain.cpp
+++ b/src/SwapChain.cpp
@@ -74,14 +74,17 @@ SwapChain::SwapChain(Device* device, VkSurfaceKHR vkSurface, unsigned int numBuf
     }
 }
 
-void SwapChain::Create() {
+void SwapChain::Create(int w, int h) {
     auto* instance = device->GetInstance();
 
     const auto& surfaceCapabilities = instance->GetSurfaceCapabilities();
 
     VkSurfaceFormatKHR surfaceFormat = chooseSwapSurfaceFormat(instance->GetSurfaceFormats());
     VkPresentModeKHR presentMode = chooseSwapPresentMode(instance->GetPresentModes());
-    VkExtent2D extent = chooseSwapExtent(surfaceCapabilities, GetGLFWWindow());
+    VkExtent2D extent{ w , h };
+    if (w == 0 || h == 0) {
+        extent = chooseSwapExtent(surfaceCapabilities, GetGLFWWindow());
+    }
 
     uint32_t imageCount = surfaceCapabilities.minImageCount + 1;
     imageCount = numBuffers > imageCount ? numBuffers : imageCount;
@@ -188,9 +191,9 @@ VkSemaphore SwapChain::GetRenderFinishedVkSemaphore() const {
     return renderFinishedSemaphore;
 }
 
-void SwapChain::Recreate() {
+void SwapChain::Recreate(int w, int h) {
     Destroy();
-    Create();
+    Create(w, h);
 }
 
 bool SwapChain::Acquire() {
@@ -228,13 +231,11 @@ bool SwapChain::Present() {
 
     VkResult result = vkQueuePresentKHR(device->GetQueue(QueueFlags::Present), &presentInfo);
 
-    if (result != VK_SUCCESS) {
-        throw std::runtime_error("Failed to present swap chain image");
-    }
-
     if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
         Recreate();
         return false;
+    } else if (result != VK_SUCCESS) {
+        throw std::runtime_error("Failed to present swap chain image");
     }
 
     return true;

--- a/src/SwapChain.h
+++ b/src/SwapChain.h
@@ -17,14 +17,14 @@ public:
     VkSemaphore GetImageAvailableVkSemaphore() const;
     VkSemaphore GetRenderFinishedVkSemaphore() const;
     
-    void Recreate();
+    void Recreate(int w = 0, int h = 0);
     bool Acquire();
     bool Present();
     ~SwapChain();
 
 private:
     SwapChain(Device* device, VkSurfaceKHR vkSurface, unsigned int numBuffers);
-    void Create();
+    void Create(int w = 0, int h = 0);
     void Destroy();
 
     Device* device;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@ namespace {
         if (width == 0 || height == 0) return;
 
         vkDeviceWaitIdle(device->GetVkDevice());
-        swapChain->Recreate();
+        swapChain->Recreate(width, height);
         renderer->RecreateFrameResources();
     }
 


### PR DESCRIPTION
Pass the width and height from resizeCallback to swapChain creation function directly, because glfwGetWindowSize() might not return the updated width and height before the swapchain update